### PR TITLE
feat(talk): add picture in picture

### DIFF
--- a/frontend/src/components/PictureInPicture.js
+++ b/frontend/src/components/PictureInPicture.js
@@ -1,0 +1,36 @@
+import React, { useState, useEffect } from "react";
+
+import IconButton from "@material-ui/core/IconButton";
+import PictureInPictureAltIcon from "@material-ui/icons/PictureInPictureAlt";
+
+const PictureInPicture = () => {
+  const [isDisabled, setIsDisabled] = useState(false)
+  const [isPipOpen, setIsPipOpen] = useState(false)
+  useEffect(() => {
+    if (!("pictureInPictureEnabled" in document)) {
+      setIsDisabled(true)
+    }
+  }, [])
+
+  const togglePictureInPicture = async () => {
+    if (!isPipOpen) {
+      await document.querySelector("#largeVideo").requestPictureInPicture()
+      setIsPipOpen(true)
+      return
+    }
+    await document.querySelector("#largeVideo").exitPictureInPicture()
+    setIsPipOpen(false)
+  }
+
+  return (
+    <IconButton
+      color="inherit"
+      onClick={togglePictureInPicture}
+      disabled={isDisabled}
+    >
+      <PictureInPictureAltIcon />
+    </IconButton>
+  )
+}
+
+export default PictureInPicture;

--- a/frontend/src/morpheus/containers/RoomAppBar.js
+++ b/frontend/src/morpheus/containers/RoomAppBar.js
@@ -6,6 +6,7 @@ import AppBarTitle from "../../components/AppBarTitle";
 import MenuRoom from "../../components/MenuRoom";
 import ShareModal from "../../components/ShareModal";
 import LofiPopper from "../../components/LofiPopper";
+import PictureInPicture from "../../components/PictureInPicture";
 import { selectRooms, selectSystemSettings } from "../store/selectors";
 import { emitLeftMeeting } from "../socket";
 import { changeSystemSetting, toggleTheme } from "../store/actions";
@@ -43,6 +44,7 @@ const RoomAppBar = ({
         onChangeTheme={onChangeTheme}
         settings={settings}
       />
+      <PictureInPicture />
       <LofiPopper
         open={isLofiOn}
         onClose={() => {


### PR DESCRIPTION
### Description
Add button to enable "picture in picture".

### How to test?
Enter in a meeting and click:
![image](https://user-images.githubusercontent.com/22479477/82059970-15eb5e80-969d-11ea-9d3c-3b3761acf6a9.png)
Click again to close

### Expected behavior
Open a "Picture in picture" window of the meeting.